### PR TITLE
Small addition to the port() function of FatTreeTopo

### DIFF
--- a/ripl/dctopo.py
+++ b/ripl/dctopo.py
@@ -371,6 +371,10 @@ class FatTreeTopo(StructuredTopo):
             src_port: port on source switch leading to the destination switch
             dst_port: port on destination switch leading to the source switch
         '''
+        # If there are non-FatTree nodes, query the superclass for ports
+        if not (hasattr(self.node_info[src], 'layer') and hasattr(self.node_info[dst], 'layer')):
+            return super(FatTreeTopo, self).port(src, dst)
+
         src_layer = self.layer(src)
         dst_layer = self.layer(dst)
 


### PR DESCRIPTION
The port() function assumes that each node has a "layer" attribute. This addition is a sanity check at the beginning of the function that checks for this attribute, and if the attribute is absent, returns the result of the superclass's port() function.
